### PR TITLE
Allow the Erlang empty tuple {} to represent an empty JSON struct.

### DIFF
--- a/src/erlson.erl
+++ b/src/erlson.erl
@@ -270,6 +270,7 @@ encode_json_term(L) when is_list(L) ->
         % otherwise, encode as JSON array
         [ encode_json_term(X) || X <- L ]
     end;
+encode_json_term({}) -> {struct, []};
 encode_json_term(_) ->
     throw('erlson_bad_json').
 


### PR DESCRIPTION
Without this, it is impossible to represent the JSON {"foo": {}}, because
erlson turns an empty Erlang proplist into an empty JSON list.
