### PR TITLE
Accept binaries as struct keys.

### DIFF
--- a/src/erlson.erl
+++ b/src/erlson.erl
@@ -97,7 +97,7 @@ not_found() ->
     Value :: any(),
     Dict :: orddict() ) -> orddict().
 
-store(Name, Value, Dict) when is_atom(Name) ->
+store(Name, Value, Dict) when is_atom(Name); is_binary(Name) ->
     store_val(Name, Value, Dict);
 store(Path, Value, Dict) ->
     try
@@ -116,6 +116,9 @@ store_path([H|T], Value, Dict) ->
     NewInnerDict = store_path(T, Value, InnerDict),
     store_val(H, NewInnerDict, Dict).
 
+
+store_val(Name, Value, Dict) when is_binary(Name) ->
+    orddict:store(decode_json_field_name(Name), Value, Dict);
 
 store_val(Name, Value, Dict) ->
     orddict:store(Name, Value, Dict).
@@ -187,7 +190,7 @@ from_proplist_1(_, _) ->
     throw('erlson_bad_proplist').
 
 
-store_proplist_elem({N, V}, Dict, MaxDepth) when is_atom(N) ->
+store_proplist_elem({N, V}, Dict, MaxDepth) when is_atom(N); is_binary(N) ->
     Value =
         case MaxDepth of
             0 -> V; % we've riched the maximum nesting depth
@@ -200,7 +203,7 @@ store_proplist_elem({N, V}, Dict, MaxDepth) when is_atom(N) ->
         end,
     store_val(N, Value, Dict);
 
-store_proplist_elem(X, Dict, _MaxDepth) when is_atom(X) ->
+store_proplist_elem(X, Dict, _MaxDepth) when is_atom(X); is_binary(X) ->
     store_val(X, true, Dict);
 
 store_proplist_elem(_X, _Dict, _MaxDepth) ->
@@ -326,9 +329,8 @@ from_json_fields(L) ->
 
 
 store_json_field({N, V}, Dict) ->
-    Name = decode_json_field_name(N),
     Value = decode_json_term(V),
-    store_val(Name, Value, Dict).
+    store_val(N, Value, Dict).
 
 
 % the way Erlson treats field names is important. Each field can be represented


### PR DESCRIPTION
Have store_val accept a binary as the key, and use the same
binary_to_existing_atom path to make sure that they get created as atoms
when appropriate (i.e. the same as from_json).
