### PR TITLE
fixed specs for list_from_json_array/1 and list_to_json_array/1

### DIFF
--- a/src/erlson.erl
+++ b/src/erlson.erl
@@ -256,8 +256,10 @@ to_json_term(Dict) ->
     end.
 
 
-% @doc Convert a list of Erlson dictionaries to a JSON array
--spec list_to_json_array/1 :: (List :: [orddict()]) -> iolist().
+% @doc Convert a list of json terms to a JSON array
+-spec list_to_json_array/1 ::
+    (List :: [orddict() | 'undefined' | binary() | atom() | integer() | float()
+            | boolean() | {'json', binary()} | {json, list()}]) -> iolist().
 list_to_json_array(List) ->
     JsonStruct = list_to_json_term(List),
     mochijson2:encode(JsonStruct).
@@ -324,8 +326,9 @@ from_json_term(JsonTerm) ->
     erlang:error('erlson_json_struct_expected', [JsonTerm]).
 
 
-% @doc Create list of Erlson dictionaries from JSON array
--spec list_from_json_array/1 :: (Json :: iodata()) -> [orddict()].
+% @doc Create list of json terms from JSON array
+ -spec list_from_json_array/1 :: (Json :: iodata()) ->
+    [orddict() | binary() | integer() | float() | boolean() | 'undefined'].
 list_from_json_array(Json) ->%, list_to_json_array, list_from_json_term and list_to_json_term
     JsonTerm = mochijson2:decode(Json),
     list_from_json_term(JsonTerm).


### PR DESCRIPTION
While I was getting rid of dialyzer warnings in my code, I found out that specs from list_to/from_json_array are more strict then success typing.

Initially I thought to introduce new 

```
-type json_term :: orddict() | binary() | integer() | float() | boolean() | 'undefined'.
```

and use it for both conversion functions, but in fact `list_to_json_array/1` accepts wider range of values than `list_from_json_array/1`, so I spec'ed them separately.
